### PR TITLE
Joystickwake no longer needed

### DIFF
--- a/install-pkgs
+++ b/install-pkgs
@@ -12,7 +12,6 @@ morewaita-icon-theme
 wine
 gamescope
 gamescope-shaders
-joystickwake
 latencyflex-vulkan-layer
 gnome-randr-rust
 wlr-randr


### PR DESCRIPTION
due to: https://github.com/ublue-os/bazzite/commit/e8bc2fb1e15e65627fc30c2d831c7cd632942b67