### PR TITLE
fix: remove unwanted software

### DIFF
--- a/remove-pkgs
+++ b/remove-pkgs
@@ -2,3 +2,8 @@ code
 ptyxis
 virt-viewer
 solaar
+simple-scan
+gnome-shell-extension-appindicator
+gnome-shell-extension-blur-my-shell
+gnome-shell-extension-dash-to-dock
+gnome-shell-extension-logo-menu


### PR DESCRIPTION
remove some unused gnome extensions and simple-scan, that is already added to the list of flatpaks